### PR TITLE
Include year and week number in build cache key

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,6 +7,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '30 6 * * 1'  # At 06:30 on Monday, every Monday.
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -20,12 +22,23 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      # http://man7.org/linux/man-pages/man1/date.1.html
+      - name: Create Cache Key
+        id: cache-key
+        run: |
+          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
+        shell: bash
+
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
       # Enable caching of Docker layers
       - uses: satackey/action-docker-layer-caching@v0.0.8
         continue-on-error: true
+        with:
+          key: docker-cache-${{ steps.cache-key.outputs.key }}-{hash}
+          restore-keys: |
+            docker-cache-${{ steps.cache-key.outputs.key }}-
 
       # Run the make script
       - name: Make build


### PR DESCRIPTION
Also schedule a build to run at 06:30 in the morning, every Monday.
This way, the JDK and Netty 5 snapshots will be updated in the build cache every week.