### PR TITLE
Add benchmarks for opening/closing shared/confined native/heap memory segments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,7 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.18.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/src/test/java/io/netty/buffer/api/BufTest.java
+++ b/src/test/java/io/netty/buffer/api/BufTest.java
@@ -1513,7 +1513,7 @@ public class BufTest {
     }
 
     @ParameterizedTest
-    @MethodSource("poolingAllocators")
+    @MethodSource("allocators")
     public void pooledBuffersMustResetStateBeforeReuse(Fixture fixture) {
         try (Allocator allocator = fixture.createAllocator();
              Buf expected = allocator.allocate(8)) {

--- a/src/test/java/io/netty/buffer/api/benchmarks/MemSegBufAccessBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemSegBufAccessBenchmark.java
@@ -13,8 +13,10 @@
 * License for the specific language governing permissions and limitations
 * under the License.
 */
-package io.netty.buffer.api;
+package io.netty.buffer.api.benchmarks;
 
+import io.netty.buffer.api.Allocator;
+import io.netty.buffer.api.Buf;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;

--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentCloseBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentCloseBenchmark.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.benchmarks;
+
+import jdk.incubator.foreign.MemorySegment;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 5, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Benchmark)
+public class MemorySegmentCloseBenchmark {
+    @Param({"0", "10", "100"})
+    public int unrelatedThreads;
+
+    @Param({"16"/*, "124", "1024"*/})
+    public int size;
+
+    public ExecutorService unrelatedThreadPool;
+    public byte[] array;
+
+    @Setup
+    public void setUp() {
+        unrelatedThreadPool = unrelatedThreads > 0? Executors.newFixedThreadPool(unrelatedThreads) : null;
+        array = new byte[size];
+    }
+
+    @TearDown
+    public void tearDown() throws InterruptedException {
+        if (unrelatedThreadPool != null) {
+            unrelatedThreadPool.shutdown();
+            unrelatedThreadPool.awaitTermination(1, TimeUnit.MINUTES);
+            unrelatedThreadPool = null;
+        }
+    }
+
+    @Benchmark
+    public MemorySegment heapConfined() {
+        try (MemorySegment segment = MemorySegment.ofArray(array)) {
+            return segment;
+        }
+    }
+
+    @Benchmark
+    public MemorySegment heapShared() {
+        try (MemorySegment segment = MemorySegment.ofArray(array).share()) {
+            return segment;
+        }
+    }
+
+    @Benchmark
+    public MemorySegment nativeConfined() {
+        try (MemorySegment segment = MemorySegment.allocateNative(size)) {
+            return segment;
+        }
+    }
+
+    @Benchmark
+    public MemorySegment nativeShared() {
+        try (MemorySegment segment = MemorySegment.allocateNative(size).share()) {
+            return segment;
+        }
+    }
+}


### PR DESCRIPTION
The numbers currently say that shared segments are quite expensive to open and close, regardless of how many threads running in the JVM. JFR profiling indicates that the `HandshakeAllThreads` VM operation is taking up most of the time, but JFR is not able to pin-point it further than that, since VM operations don't carry stack traces.

```
Benchmark                                   (size)  (unrelatedThreads)  Mode  Cnt      Score     Error  Units
MemorySegmentCloseBenchmark.heapConfined        16                   0  avgt   50     33,097 ±   1,914  ns/op
MemorySegmentCloseBenchmark.heapConfined        16                  10  avgt   50     33,471 ±   1,904  ns/op
MemorySegmentCloseBenchmark.heapConfined        16                 100  avgt   50     33,289 ±   1,962  ns/op
MemorySegmentCloseBenchmark.heapShared          16                   0  avgt   50  19675,203 ± 343,392  ns/op
MemorySegmentCloseBenchmark.heapShared          16                  10  avgt   50  19396,607 ± 337,509  ns/op
MemorySegmentCloseBenchmark.heapShared          16                 100  avgt   50  19366,129 ± 308,155  ns/op
MemorySegmentCloseBenchmark.nativeConfined      16                   0  avgt   50    256,534 ±   3,996  ns/op
MemorySegmentCloseBenchmark.nativeConfined      16                  10  avgt   50    256,942 ±   3,888  ns/op
MemorySegmentCloseBenchmark.nativeConfined      16                 100  avgt   50    255,618 ±   4,298  ns/op
MemorySegmentCloseBenchmark.nativeShared        16                   0  avgt   50  19328,519 ± 105,996  ns/op
MemorySegmentCloseBenchmark.nativeShared        16                  10  avgt   50  18997,370 ± 249,796  ns/op
MemorySegmentCloseBenchmark.nativeShared        16                 100  avgt   50  18775,365 ± 234,154  ns/op
```