### PR TITLE
Add benchmarks examining the performance difference between explicitly closing buffers, and letting Cleaners close the buffers

### DIFF
--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.benchmarks;
+
+import io.netty.buffer.api.Allocator;
+import io.netty.buffer.api.Buf;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+@Warmup(iterations = 30, time = 1)
+@Measurement(iterations = 30, time = 1)
+@Fork(value = 5, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class MemorySegmentClosedByCleanerBenchmark {
+    private static final Allocator direct = Allocator.direct();
+    private static final Allocator withCleaner = Allocator.directWithCleaner();
+
+    @Param({"heavy", "light"})
+    public String workload;
+    public boolean isHeavy;
+
+    @Setup
+    public void setUp() {
+        if ("heavy".equals(workload)) {
+            isHeavy = true;
+        } else if ("light".equals(workload)) {
+            isHeavy = false;
+        } else {
+            throw new IllegalArgumentException("Unsupported workload: " + workload);
+        }
+    }
+
+    @Benchmark
+    public Buf explicitClose() throws Exception {
+        try (Buf buf = process(direct.allocate(256))) {
+            return buf;
+        }
+    }
+
+    @Benchmark
+    public Buf cleanerClose() throws Exception {
+        return process(withCleaner.allocate(256));
+    }
+
+    private Buf process(Buf buffer) throws Exception {
+        // Simulate some async network server thingy, processing the buffer.
+        var tlr = ThreadLocalRandom.current();
+        if (isHeavy) {
+            return completedFuture(buffer.send()).thenApplyAsync(send -> {
+                try (Buf buf = send.receive()) {
+                    while (buf.writableBytes() > 0) {
+                        buf.writeByte((byte) tlr.nextInt());
+                    }
+                    return buf.send();
+                }
+            }).thenApplyAsync(send -> {
+                try (Buf buf = send.receive()) {
+                    byte b = 0;
+                    while (buf.readableBytes() > 0) {
+                        b += buf.readByte();
+                    }
+                    buf.fill(b);
+                    return buf.send();
+                }
+            }).get().receive();
+        } else {
+            while (buffer.writableBytes() > 0) {
+                buffer.writeByte((byte) tlr.nextInt());
+            }
+            byte b = 0;
+            while (buffer.readableBytes() > 0) {
+                b += buffer.readByte();
+            }
+            buffer.fill(b);
+            return buffer;
+        }
+    }
+}


### PR DESCRIPTION
This PR is based on #3

The story on whether to rely on cleaners or not, is more complicated. But first up, the results:

```
Benchmark                                                 (workload)  Mode  Cnt     Score      Error  Units
MemorySegmentClosedByCleanerBenchmark.cleanerClose             heavy  avgt  150   254,087 ±   19,722  us/op
MemorySegmentClosedByCleanerBenchmark.cleanerClose             light  avgt  150  4023,469 ± 4759,030  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose            heavy  avgt  150   487,768 ±   13,892  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose            light  avgt  150     2,108 ±    0,055  us/op
```

In summary, if we have a very high level of allocation/deallocation activity, then relying on cleaners is *much* worse than relying on explicit closing. Perhaps the cleaners are not able to keep up? And the allocating threads gets hit with some heavy throttling? This needs to be investigated further. On the other hand, if the buffer allocation/deallocation is only a small part of the workload, then it is much more efficient to deallocate memory in a background thread, i.e. the cleaner.

Okay… enough with the speculation. It's time to channel our inner Shipilev and look into _why_ we get the numbers we do.
The benchmarks ran with JFR profiling enabled, and the resulting [jfr files](https://drive.google.com/file/d/1Mw6-HL6iZLSpewy7_Y9oE697RU64xTLy/view?usp=sharing) give us some interesting insights into what's going on.

Before diving in, a brief explanation of what the benchmark does. We're trying to simulate some multi-threaded, networked program that processes some packets of data. The "packets", aka. the buffers we allocate, are always 256 bytes in size, and always allocated from native memory. The processing of those buffers involve filling them with random data - which means we write the whole buffer - then computing the sum, as a byte, of those random bytes - which means we read the whole buffer - and then finally we overwrite the contents of the buffer by filling it with the computed sum.
All of this happens on one of two ways, which is the `light` and the `heavy` workloads. The `light` workload does all of the above in-line, in the benchmarking thread. The `heavy` workload sends the buffer into the common Fork/Join pool via a CompletableFuture, and perform the buffer filling and sum computations as separate tasks. The tasks are then joined back into the benchmarking thread when they complete. Because the buffers are confined, we have to use `send()` in order to transfer ownership between threads and tasks in the `heavy` workload.

First, the `cleanerClose` with the `light` workload. This benchmark showed the worst overall performance. Because the workload is _light_, the benchmark threads initially get a lot of stuff done, but are then punished by the GC for the mess they make. The flight recording shows 15 GCs of about 1.3 seconds each, so nearly 20 of the 30 seconds benchmark running time are spent doing GC. The memory pressure on the overall system also grows very large during this benchmark.
This tells us that relying on the Cleaner for releasing all buffers will not scale well to heavily loaded systems. At least not with standard G1GC settings.

The `explicitClose` with the `light` workload doesn't show anything special in the profile. It has 13 GCs, with the longest taking 61 ms, and ~85% of the time in the benchmark is spent in the buffer processing method, and another roughly ~5% of the time is spent in the buffer allocation. This is what the good baseline looks like.

So far this indicates that explicitly closing our buffers, is vastly superior to relying on cleaners. This changes in the `heavy` workload, where the buffers are sent between and processed in different threads. The culprit turns out to be how `send()` is implemented: in order to allow an unknown future thread to claim the underlying memory segment, we turn the thread-confined memory segment into a _shared_ "transfer" segment. The transfer segment is then encapsulated in the Send object, so the future recipient can claim the segment for itself with `handoff()`. As we learned in #3, it is expensive to create and close shared memory segments, but then why is the cleaner-based version of that code nearly twice as fast as the explicitly closed one? The answer is that the JDK can play a cute trick in the case with the Cleaner. The reason it's expensive to close a shared segment, is that the JDK has to make sure that no other threads can have racy access to the memory while it is being released. The JDK ensures this by doing a thread-local handshake with all threads in the system, and in this handshake, the threads have their local variables scanned to check if they are holding references to the segment being closed. If that's the case, the close is aborted. Otherwise, if there were no live references being immediately work on (it's okay to have references further up a threads stack, because they will properly observe that the segment has been closed) then the closing succeeds. On the other hand, when a shared segment is closed by the cleaner, the JDK _knows_ that there are no other references to the segment anywhere – if there were, it wouldn't have become phantom reachable in the first place. This allows the JDK to close the shared segment _without_ doing a thread-local handshake with all threads.
Furthermore, because of the costly transformations to and from shared segments, and because of the thread-synchronisation overheads inherently involved in the `heavy` workload, the Cleaner and the GC never seem to fall behind in that benchmark. Only two GCs are performed of 166ms and 183ms, respectively. The `explicitlyClose` benchmark with the `heavy` workload only perform a single 30ms GC, however, so there is still a noticeable cost to responsiveness when relying on the cleaner, but overall system throughput is much better when the closing of many of the shared segments can be left to the cleaner.

So in conclusion, it's not immediately obvious which way is the best in general. What we _have_ learned, however, is that the costs associated with shared segments needs to be looked at further. For instance, it might be advantageous to leave the memory segments in a shared state after the first send. Then a segment would be transformed at most once, since future send calls can just carry over the existing shared segment. We could also ask the panama-foreign project for an API that would allow us to implement `send()` without transferring through a shared segment.