### PR TITLE
Make Buf.send() faster

### DIFF
--- a/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
+++ b/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
@@ -712,8 +712,7 @@ class MemSegBuf extends RcSupport<Buf, MemSegBuf> implements Buf {
         return new Owned<MemSegBuf>() {
             @Override
             public MemSegBuf transferOwnership(Drop<MemSegBuf> drop) {
-                var newSegment = isConfined? transferSegment.handoff(Thread.currentThread()) : transferSegment;
-                MemSegBuf copy = new MemSegBuf(newSegment, drop, alloc);
+                MemSegBuf copy = new MemSegBuf(transferSegment, drop, alloc);
                 copy.order = outer.order;
                 copy.roff = outer.roff;
                 copy.woff = outer.woff;


### PR DESCRIPTION
When we `send()` a confined buffer, we had to first turn it into a shard buffer, so that it could be claimed by an arbitrary recipient thread.

As we've learned, however, closing shared segments is expensive.
We can speed up the send() call by simply leaving the segment shared.
This weakens the confinement of the received segment, though.
Currently no tests fails on that, but in the future we should re-implement confinement checking inside the Buf implementations themselves any, because pooled buffers also violate the confinement restriction, and we have a guiding principle that all buffers, regardless of implementation, should always behave the same.

The results of this change can be observed in the MemorySegmentClosedByCleanerBenchmark, with the heavy workload.
Explicitly closed segments now run the workload twice as fast, and the cleaner based closing is now 3 times faster.

```
Before:
Benchmark                                            (workload)  Mode  Cnt   Score   Error  Units
MemorySegmentClosedByCleanerBenchmark.cleanerClose        heavy  avgt  150  42,221 ± 0,943  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose       heavy  avgt  150  65,215 ± 0,761  us/op

After:
Benchmark                                            (workload)  Mode  Cnt   Score   Error  Units
MemorySegmentClosedByCleanerBenchmark.cleanerClose        heavy  avgt  150  13,871 ± 0,544  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose       heavy  avgt  150  37,516 ± 0,426  us/op
```