### PR TITLE
Add benchmark for closing pooled buffers

### DIFF
--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
@@ -43,6 +43,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class MemorySegmentClosedByCleanerBenchmark {
     private static final Allocator direct = Allocator.direct();
     private static final Allocator withCleaner = Allocator.directWithCleaner();
+    private static final Allocator directPooled = Allocator.pooledDirect();
 
     @Param({"heavy", "light"})
     public String workload;
@@ -62,6 +63,13 @@ public class MemorySegmentClosedByCleanerBenchmark {
     @Benchmark
     public Buf explicitClose() throws Exception {
         try (Buf buf = process(direct.allocate(256))) {
+            return buf;
+        }
+    }
+
+    @Benchmark
+    public Buf explicitPooledClose() throws Exception {
+        try (Buf buf = process(directPooled.allocate(256))) {
             return buf;
         }
     }


### PR DESCRIPTION
Motivation:
Pooled buffers are a very important use case, and they change the cost dynamics around shared memory segments, so it's worth looking into in detail.

Modification:
Add another explicit close of pooled direct buffers to MemorySegmentClosedByCleanerBenchmark

Result:
Explicitly closing of pooled buffers is even out-performing cleaner close on the "heavy" workload, so this is currently the fastest way to run that workload:

```
Benchmark                                                  (workload)  Mode  Cnt   Score   Error  Units
MemorySegmentClosedByCleanerBenchmark.cleanerClose              heavy  avgt  150  14,194 ± 0,558  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose             heavy  avgt  150  40,496 ± 0,414  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledClose       heavy  avgt  150  12,723 ± 0,134  us/op
```