### PR TITLE
Make it possible to extend composite buffers after creation

### DIFF
--- a/src/main/java/io/netty/buffer/api/Allocator.java
+++ b/src/main/java/io/netty/buffer/api/Allocator.java
@@ -112,6 +112,27 @@ public interface Allocator extends AutoCloseable {
     }
 
     /**
+     * Extend the given composite buffer with the given extension buffer.
+     * This works as if the extension had originally been included at the end of the list of constituent buffers when
+     * the composite buffer was created.
+     * The composite buffer is modified in-place.
+     *
+     * @see #compose(Buf...)
+     * @param composite The composite buffer (from a prior {@link #compose(Buf...)} call) to extend with the given
+     *                 extension buffer.
+     * @param extension The buffer to extend the composite buffer with.
+     */
+    static void extend(Buf composite, Buf extension) {
+        if (composite.getClass() != CompositeBuf.class) {
+            throw new IllegalArgumentException(
+                    "Expected the first buffer to be a composite buffer, " +
+                    "but it is a " + composite.getClass() + " buffer: " + composite + '.');
+        }
+        CompositeBuf buf = (CompositeBuf) composite;
+        buf.extendWith(extension);
+    }
+
+    /**
      * Close this allocator, freeing all of its internal resources. It is not specified if the allocator can still be
      * used after this method has been called on it.
      */


### PR DESCRIPTION
Motivation:
Composite buffers are uniquely positioned to be able to extend their underlying storage relatively cheaply.
This fact is relied upon in a couple of buffer use cases within Netty, that we wish to support.

Modification:
Add a static `extend` method to Allocator, so that the CompositeBuf class can remain internal.
The `extend` method inserts the extension buffer at the end of the composite buffer as if it had been included from the start.
This involves checking offsets and byte order invariants.
We also require that the composite buffer be in an owned state.

Result:
It's now possible to extend a composite buffer with a specific buffer, after the composite buffer has been created.