### PR TITLE
Make Buf.send() faster, again

### DIFF
--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
@@ -34,8 +34,8 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-@Warmup(iterations = 30, time = 1)
-@Measurement(iterations = 30, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
 @Fork(value = 5, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)


### PR DESCRIPTION
Motivation:
This will likely be a somewhat common operation, as buffers move between eventloop and worker threads, so it's important to have an understanding of how it performs.

Modification:
Add a benchmark that specifically targets the send() operation on buffers.
Use a dedicated transfer thread to facilitate the handoff of thread-confined memory segments, from one thread to another.
By using a separate thread for this, we no longer need to create and close a shared segment, sparing us of the thread-local handshake costs related to that.

Result:
We got benchmark numbers that clearly show the cost of confinement transfer, and sending a thread-confined buffer from one thread to another is now about twice as fast.

Before:

```
Benchmark                    Mode  Cnt   Score   Error  Units
SendBenchmark.sendNonPooled  avgt   50  31,348 ± 0,406  us/op
SendBenchmark.sendPooled     avgt   50   8,626 ± 0,165  us/op

Benchmark                                                  (workload)  Mode  Cnt   Score   Error  Units
MemorySegmentClosedByCleanerBenchmark.cleanerClose              heavy  avgt   50  13,121 ± 0,806  us/op
MemorySegmentClosedByCleanerBenchmark.cleanerClose              light  avgt   50   2,269 ± 0,462  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose             heavy  avgt   50  36,795 ± 0,666  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose             light  avgt   50   1,291 ± 0,063  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledClose       heavy  avgt   50  11,722 ± 0,231  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledClose       light  avgt   50   1,063 ± 0,011  us/op
```

After:

```
Benchmark                    Mode  Cnt   Score   Error  Units
SendBenchmark.sendNonPooled  avgt   50  15,788 ± 0,206  us/op
SendBenchmark.sendPooled     avgt   50   8,475 ± 0,072  us/op

Benchmark                                                  (workload)  Mode  Cnt   Score   Error  Units
MemorySegmentClosedByCleanerBenchmark.cleanerClose              heavy  avgt   50  26,931 ± 1,001  us/op
MemorySegmentClosedByCleanerBenchmark.cleanerClose              light  avgt   50   2,430 ± 0,513  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose             heavy  avgt   50  24,413 ± 0,237  us/op
MemorySegmentClosedByCleanerBenchmark.explicitClose             light  avgt   50   1,142 ± 0,018  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledClose       heavy  avgt   50  11,858 ± 0,216  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledClose       light  avgt   50   1,071 ± 0,009  us/op
```