### PR TITLE
Add a benchmark for Buf.send() 

### DIFF
--- a/src/test/java/io/netty/buffer/api/benchmarks/ByteIterationBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/ByteIterationBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/src/test/java/io/netty/buffer/api/benchmarks/MemSegBufAccessBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemSegBufAccessBenchmark.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2019 The Netty Project
+* Copyright 2020 The Netty Project
 *
 * The Netty Project licenses this file to you under the Apache License,
 * version 2.0 (the "License"); you may not use this file except in compliance

--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentCloseBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentCloseBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/src/test/java/io/netty/buffer/api/benchmarks/SendBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/SendBenchmark.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api.benchmarks;
+
+import io.netty.buffer.api.Allocator;
+import io.netty.buffer.api.Buf;
+import io.netty.buffer.api.Send;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(value = 5, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class SendBenchmark {
+    private static final Allocator nonPooled = Allocator.heap();
+    private static final Allocator pooled = Allocator.pooledHeap();
+    private static final Function<Send<Buf>, Send<Buf>> bounce = send -> {
+        try (Buf buf = send.receive()) {
+            return buf.send();
+        }
+    };
+
+    @Benchmark
+    public Buf sendNonPooled() throws Exception {
+        try (Buf buf = nonPooled.allocate(8)) {
+            try (Buf receive = completedFuture(buf.send()).thenApplyAsync(bounce).get().receive()) {
+                return receive;
+            }
+        }
+    }
+
+    @Benchmark
+    public Buf sendPooled() throws Exception {
+        try (Buf buf = pooled.allocate(8)) {
+            try (Buf receive = completedFuture(buf.send()).thenApplyAsync(bounce).get().receive()) {
+                return receive;
+            }
+        }
+    }
+}

--- a/src/test/java/io/netty/buffer/api/benchmarks/SendBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/SendBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The Netty Project
+ * Copyright 2020 The Netty Project
  *
  * The Netty Project licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -40,9 +40,9 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 public class SendBenchmark {
-    private static final Allocator nonPooled = Allocator.heap();
-    private static final Allocator pooled = Allocator.pooledHeap();
-    private static final Function<Send<Buf>, Send<Buf>> bounce = send -> {
+    private static final Allocator NON_POOLED = Allocator.heap();
+    private static final Allocator POOLED = Allocator.pooledHeap();
+    private static final Function<Send<Buf>, Send<Buf>> BUFFER_BOUNCE = send -> {
         try (Buf buf = send.receive()) {
             return buf.send();
         }
@@ -50,8 +50,8 @@ public class SendBenchmark {
 
     @Benchmark
     public Buf sendNonPooled() throws Exception {
-        try (Buf buf = nonPooled.allocate(8)) {
-            try (Buf receive = completedFuture(buf.send()).thenApplyAsync(bounce).get().receive()) {
+        try (Buf buf = NON_POOLED.allocate(8)) {
+            try (Buf receive = completedFuture(buf.send()).thenApplyAsync(BUFFER_BOUNCE).get().receive()) {
                 return receive;
             }
         }
@@ -59,8 +59,8 @@ public class SendBenchmark {
 
     @Benchmark
     public Buf sendPooled() throws Exception {
-        try (Buf buf = pooled.allocate(8)) {
-            try (Buf receive = completedFuture(buf.send()).thenApplyAsync(bounce).get().receive()) {
+        try (Buf buf = POOLED.allocate(8)) {
+            try (Buf receive = completedFuture(buf.send()).thenApplyAsync(BUFFER_BOUNCE).get().receive()) {
                 return receive;
             }
         }


### PR DESCRIPTION
Motivation:
This will likely be a somewhat common operation, as buffers move between eventloop and worker threads, so it's important to have an understanding of how it performs.

Modification:
Add a benchmark that specifically targets the send() operation on buffers.

Result:
We got benchmark numbers that clearly show the cost of confinement transfer.