### PR TITLE
Add BufHolder and BufRef helper classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ dbg:
 
 clean:
 	docker rm -fv build-container-dbg
+	docker rm -fv build-container
 
 build: image
 	docker create --name build-container netty-incubator-buffer:build

--- a/src/main/java/io/netty/buffer/api/Allocator.java
+++ b/src/main/java/io/netty/buffer/api/Allocator.java
@@ -123,13 +123,22 @@ public interface Allocator extends AutoCloseable {
      * @param extension The buffer to extend the composite buffer with.
      */
     static void extend(Buf composite, Buf extension) {
-        if (composite.getClass() != CompositeBuf.class) {
+        if (!isComposite(composite)) {
             throw new IllegalArgumentException(
                     "Expected the first buffer to be a composite buffer, " +
                     "but it is a " + composite.getClass() + " buffer: " + composite + '.');
         }
         CompositeBuf buf = (CompositeBuf) composite;
         buf.extendWith(extension);
+    }
+
+    /**
+     * Check if the given buffer is a {@linkplain #compose(Buf...) composite} buffer or not.
+     * @param composite The buffer to check.
+     * @return {@code true} if the given buffer was created with {@link #compose(Buf...)}, {@code false} otherwise.
+     */
+    static boolean isComposite(Buf composite) {
+        return composite.getClass() == CompositeBuf.class;
     }
 
     /**

--- a/src/main/java/io/netty/buffer/api/BufHolder.java
+++ b/src/main/java/io/netty/buffer/api/BufHolder.java
@@ -86,12 +86,7 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
     @Override
     public Send<T> send() {
         var send = buf.send();
-        return new Send<T>() {
-            @Override
-            public T receive() {
-                return BufHolder.this.receive(send.receive());
-            }
-        };
+        return () -> receive(send.receive());
     }
 
     /**
@@ -116,7 +111,7 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
      *
      * @param newBuf The new {@link Buf} instance that is replacing the currently held buffer.
      */
-    protected void replace(Buf newBuf) {
+    protected final void replaceBuf(Buf newBuf) {
         try (var ignore = buf) {
             buf = newBuf.acquire();
         }
@@ -134,7 +129,7 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
      *
      * @param send The new {@link Buf} instance that is replacing the currently held buffer.
      */
-    protected void replace(Send<Buf> send) {
+    protected final void replaceBuf(Send<Buf> send) {
         try (var ignore = buf) {
             buf = send.receive();
         }
@@ -152,7 +147,7 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
      *
      * @param newBuf The new {@link Buf} instance that is replacing the currently held buffer.
      */
-    protected void replaceVolatile(Buf newBuf) {
+    protected final void replaceBufVolatile(Buf newBuf) {
         var prev = (Buf) BUF.getAndSet(this, newBuf.acquire());
         prev.close();
     }
@@ -167,9 +162,9 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
      * <p>
      * The buffer assignment is performed using a volatile store.
      *
-     * @param send The new {@link Buf} instance that is replacing the currently held buffer.
+     * @param send The {@link Send} with the new {@link Buf} instance that is replacing the currently held buffer.
      */
-    protected void replaceVolatile(Send<Buf> send) {
+    protected final void replaceBufVolatile(Send<Buf> send) {
         var prev = (Buf) BUF.getAndSet(this, send.receive());
         prev.close();
     }
@@ -181,7 +176,7 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
      *
      * @return The {@link Buf} instance being held by this {@linkplain T buffer holder}.
      */
-    protected Buf getBuf() {
+    protected final Buf getBuf() {
         return buf;
     }
 
@@ -192,7 +187,7 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
      *
      * @return The {@link Buf} instance being held by this {@linkplain T buffer holder}.
      */
-    protected Buf getBufVolatile() {
+    protected final Buf getBufVolatile() {
         return (Buf) BUF.getVolatile(this);
     }
 }

--- a/src/main/java/io/netty/buffer/api/BufHolder.java
+++ b/src/main/java/io/netty/buffer/api/BufHolder.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api;
+
+import java.lang.invoke.VarHandle;
+import java.util.Objects;
+
+import static io.netty.buffer.api.Statics.findVarHandle;
+import static java.lang.invoke.MethodHandles.lookup;
+
+/**
+ * The {@link BufHolder} is an abstract class that simplifies the implementation of objects that themselves contain
+ * a {@link Buf} instance.
+ * <p>
+ * The {@link BufHolder} can only hold on to a single buffer, so objects and classes that need to hold on to multiple
+ * buffers will have to do their implementation from scratch, though they can use the code of the {@link BufHolder} as
+ * inspiration.
+ * <p>
+ * If you just want an object that is a reference to a buffer, then the {@link BufRef} can be used for that purpose.
+ * If you have an advanced use case where you wish to implement {@link Rc}, and tightly control lifetimes, then
+ * {@link RcSupport} can be of help.
+ *
+ * @param <T> The concrete {@link BufHolder} type.
+ */
+public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
+    private static final VarHandle BUF = findVarHandle(lookup(), BufHolder.class, "buf", Buf.class);
+    private Buf buf;
+
+    /**
+     * Create a new {@link BufHolder} to hold the given {@linkplain Buf buffer}.
+     * <p>
+     * <strong>Note:</strong> this increases the reference count of the given buffer.
+     *
+     * @param buf The {@linkplain Buf buffer} to be held by this holder.
+     */
+    protected BufHolder(Buf buf) {
+        this.buf = Objects.requireNonNull(buf, "The buffer cannot be null.").acquire();
+    }
+
+    /**
+     * Create a new {@link BufHolder} to hold the {@linkplain Buf buffer} received from the given {@link Send}.
+     * <p>
+     * The {@link BufHolder} will then be holding exclusive ownership of the buffer.
+     *
+     * @param send The {@linkplain Buf buffer} to be held by this holder.
+     */
+    protected BufHolder(Send<Buf> send) {
+        buf = Objects.requireNonNull(send, "The send cannot be null.").receive();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public T acquire() {
+        buf.acquire();
+        return (T) this;
+    }
+
+    @Override
+    public void close() {
+        buf.close();
+    }
+
+    @Override
+    public boolean isOwned() {
+        return buf.isOwned();
+    }
+
+    @Override
+    public int countBorrows() {
+        return buf.countBorrows();
+    }
+
+    @Override
+    public Send<T> send() {
+        var send = buf.send();
+        return new Send<T>() {
+            @Override
+            public T receive() {
+                return BufHolder.this.receive(send.receive());
+            }
+        };
+    }
+
+    /**
+     * Called when a {@linkplain #send() sent} {@link BufHolder} is received by the recipient.
+     * The {@link BufHolder} should return a new concrete instance, that wraps the given {@link Buf} object.
+     *
+     * @param buf The {@link Buf} that is {@linkplain Send#receive() received} by the recipient,
+     *           and needs to be wrapped in a new {@link BufHolder} instance.
+     * @return A new {@linkplain T buffer holder} instance, containing the given {@linkplain Buf buffer}.
+     */
+    protected abstract T receive(Buf buf);
+
+    /**
+     * Replace the underlying referenced buffer with the given buffer.
+     * <p>
+     * This method is protected to permit advanced use cases of {@link BufHolder} sub-class implementations.
+     * <p>
+     * <strong>Note:</strong> this method decreases the reference count of the current buffer,
+     * and increases the reference count of the new buffer.
+     * <p>
+     * The buffer assignment is performed using a plain store.
+     *
+     * @param newBuf The new {@link Buf} instance that is replacing the currently held buffer.
+     */
+    protected void replace(Buf newBuf) {
+        try (var ignore = buf) {
+            buf = newBuf.acquire();
+        }
+    }
+
+    /**
+     * Replace the underlying referenced buffer with the given buffer.
+     * <p>
+     * This method is protected to permit advanced use cases of {@link BufHolder} sub-class implementations.
+     * <p>
+     * <strong>Note:</strong> this method decreases the reference count of the current buffer,
+     * and takes exclusive ownership of the sent buffer.
+     * <p>
+     * The buffer assignment is performed using a plain store.
+     *
+     * @param send The new {@link Buf} instance that is replacing the currently held buffer.
+     */
+    protected void replace(Send<Buf> send) {
+        try (var ignore = buf) {
+            buf = send.receive();
+        }
+    }
+
+    /**
+     * Replace the underlying referenced buffer with the given buffer.
+     * <p>
+     * This method is protected to permit advanced use cases of {@link BufHolder} sub-class implementations.
+     * <p>
+     * <strong>Note:</strong> this method decreases the reference count of the current buffer,
+     * and increases the reference count of the new buffer.
+     * <p>
+     * The buffer assignment is performed using a volatile store.
+     *
+     * @param newBuf The new {@link Buf} instance that is replacing the currently held buffer.
+     */
+    protected void replaceVolatile(Buf newBuf) {
+        var prev = (Buf) BUF.getAndSet(this, newBuf.acquire());
+        prev.close();
+    }
+
+    /**
+     * Replace the underlying referenced buffer with the given buffer.
+     * <p>
+     * This method is protected to permit advanced use cases of {@link BufHolder} sub-class implementations.
+     * <p>
+     * <strong>Note:</strong> this method decreases the reference count of the current buffer,
+     * and takes exclusive ownership of the sent buffer.
+     * <p>
+     * The buffer assignment is performed using a volatile store.
+     *
+     * @param send The new {@link Buf} instance that is replacing the currently held buffer.
+     */
+    protected void replaceVolatile(Send<Buf> send) {
+        var prev = (Buf) BUF.getAndSet(this, send.receive());
+        prev.close();
+    }
+
+    /**
+     * Access the held {@link Buf} instance.
+     * <p>
+     * The access is performed using a plain load.
+     *
+     * @return The {@link Buf} instance being held by this {@linkplain T buffer holder}.
+     */
+    protected Buf getBuf() {
+        return buf;
+    }
+
+    /**
+     * Access the held {@link Buf} instance.
+     * <p>
+     * The access is performed using a volatile load.
+     *
+     * @return The {@link Buf} instance being held by this {@linkplain T buffer holder}.
+     */
+    protected Buf getBufVolatile() {
+        return (Buf) BUF.getVolatile(this);
+    }
+}

--- a/src/main/java/io/netty/buffer/api/BufRef.java
+++ b/src/main/java/io/netty/buffer/api/BufRef.java
@@ -49,14 +49,32 @@ public final class BufRef extends BufHolder<BufRef> {
         return new BufRef(buf);
     }
 
-    @Override
-    public void replaceVolatile(Buf newBuf) {
-        super.replaceVolatile(newBuf);
+    /**
+     * Replace the underlying referenced buffer with the given buffer.
+     * <p>
+     * <strong>Note:</strong> this method decreases the reference count of the current buffer,
+     * and increases the reference count of the new buffer.
+     * <p>
+     * The buffer assignment is performed using a volatile store.
+     *
+     * @param newBuf The new {@link Buf} instance that is replacing the currently held buffer.
+     */
+    public void replace(Buf newBuf) {
+        replaceBufVolatile(newBuf);
     }
 
-    @Override
-    public void replaceVolatile(Send<Buf> send) {
-        super.replaceVolatile(send);
+    /**
+     * Replace the underlying referenced buffer with the given buffer.
+     * <p>
+     * <strong>Note:</strong> this method decreases the reference count of the current buffer,
+     * and takes exclusive ownership of the sent buffer.
+     * <p>
+     * The buffer assignment is performed using a volatile store.
+     *
+     * @param send The {@link Send} with the new {@link Buf} instance that is replacing the currently held buffer.
+     */
+    public void replace(Send<Buf> send) {
+        replaceBufVolatile(send);
     }
 
     /**

--- a/src/main/java/io/netty/buffer/api/BufRef.java
+++ b/src/main/java/io/netty/buffer/api/BufRef.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api;
+
+import java.lang.invoke.VarHandle;
+
+/**
+ * A mutable reference to a buffer.
+ */
+public final class BufRef extends BufHolder<BufRef> {
+    /**
+     * Create a reference to the given {@linkplain Buf buffer}.
+     * This increments the reference count of the buffer.
+     *
+     * @param buf The buffer to reference.
+     */
+    public BufRef(Buf buf) {
+        super(buf);
+        VarHandle.fullFence();
+    }
+
+    /**
+     * Create a reference that holds the exclusive ownership of the sent buffer.
+     *
+     * @param send The {@linkplain Send sent} buffer to take ownership of.
+     */
+    public BufRef(Send<Buf> send) {
+        super(send);
+        VarHandle.fullFence();
+    }
+
+    @Override
+    protected BufRef receive(Buf buf) {
+        return new BufRef(buf);
+    }
+
+    @Override
+    public void replaceVolatile(Buf newBuf) {
+        super.replaceVolatile(newBuf);
+    }
+
+    @Override
+    public void replaceVolatile(Send<Buf> send) {
+        super.replaceVolatile(send);
+    }
+
+    /**
+     * Access the buffer in this reference.
+     *
+     * @return The buffer held by the reference.
+     */
+    public Buf contents() {
+        return getBufVolatile();
+    }
+}

--- a/src/main/java/io/netty/buffer/api/BufRef.java
+++ b/src/main/java/io/netty/buffer/api/BufRef.java
@@ -29,6 +29,7 @@ public final class BufRef extends BufHolder<BufRef> {
      */
     public BufRef(Buf buf) {
         super(buf);
+        // BufRef is meant to be atomic, so we need to add a fence to get the semantics of a volatile store.
         VarHandle.fullFence();
     }
 
@@ -39,6 +40,7 @@ public final class BufRef extends BufHolder<BufRef> {
      */
     public BufRef(Send<Buf> send) {
         super(send);
+        // BufRef is meant to be atomic, so we need to add a fence to get the semantics of a volatile store.
         VarHandle.fullFence();
     }
 

--- a/src/main/java/io/netty/buffer/api/RcSupport.java
+++ b/src/main/java/io/netty/buffer/api/RcSupport.java
@@ -16,7 +16,6 @@
 package io.netty.buffer.api;
 
 import java.util.Objects;
-import java.util.function.Function;
 
 public abstract class RcSupport<I extends Rc<I>, T extends RcSupport<I, T>> implements Rc<I> {
     private int acquires; // Closed if negative.
@@ -83,6 +82,11 @@ public abstract class RcSupport<I extends Rc<I>, T extends RcSupport<I, T>> impl
         return new TransferSend<I, T>(owned, drop);
     }
 
+    /**
+     * Create an {@link IllegalStateException} with a custom message, tailored to this particular {@link Rc} instance,
+     * for when the object cannot be sent for some reason.
+     * @return An {@link IllegalStateException} to be thrown when this object cannot be sent.
+     */
     protected IllegalStateException notSendableException() {
         return new IllegalStateException(
                 "Cannot send() a reference counted object with " + acquires + " outstanding acquires: " + this + '.');
@@ -111,15 +115,21 @@ public abstract class RcSupport<I extends Rc<I>, T extends RcSupport<I, T>> impl
     /**
      * Get access to the underlying {@link Drop} object.
      * This method is unsafe because it open the possibility of bypassing and overriding resource lifetimes.
+     *
      * @return The {@link Drop} object used by this reference counted object.
      */
     protected Drop<T> unsafeGetDrop() {
         return drop;
     }
 
-    protected Drop<T> unsafeExchangeDrop(Drop<T> replacement) {
+    /**
+     * Replace the current underlying {@link Drop} object with the given one.
+     * This method is unsafe because it open the possibility of bypassing and overring resource lifetimes.
+     *
+     * @param replacement The new {@link Drop} object to use instead of the current one.
+     */
+    protected void unsafeSetDrop(Drop<T> replacement) {
         drop = Objects.requireNonNull(replacement, "Replacement drop cannot be null.");
-        return replacement;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/io/netty/buffer/api/Scope.java
+++ b/src/main/java/io/netty/buffer/api/Scope.java
@@ -30,7 +30,7 @@ import java.util.ArrayDeque;
  * <p>
  * Note that scopes are not thread-safe. They are intended to be used from a single thread.
  */
-public class Scope implements AutoCloseable {
+public final class Scope implements AutoCloseable {
     private final ArrayDeque<Rc<?>> deque = new ArrayDeque<>();
 
     /**

--- a/src/main/java/io/netty/buffer/api/Send.java
+++ b/src/main/java/io/netty/buffer/api/Send.java
@@ -28,6 +28,7 @@ package io.netty.buffer.api;
  *
  * @param <T>
  */
+@FunctionalInterface
 public interface Send<T extends Rc<T>> {
     /**
      * Receive the {@link Rc} instance being sent, and bind its ownership to the calling thread. The invalidation of the

--- a/src/main/java/io/netty/buffer/api/memseg/BifurcatedDrop.java
+++ b/src/main/java/io/netty/buffer/api/memseg/BifurcatedDrop.java
@@ -50,7 +50,7 @@ class BifurcatedDrop implements Drop<MemSegBuf> {
     }
 
     @Override
-    public synchronized void drop(MemSegBuf buf) {
+    public void drop(MemSegBuf buf) {
         int c;
         int n;
         do {

--- a/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
+++ b/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
@@ -322,7 +322,7 @@ class MemSegBuf extends RcSupport<Buf, MemSegBuf> implements Buf {
                 // Disconnect from the bifurcated drop, since we'll get our own fresh memory segment.
                 drop.drop(this);
                 drop = ((BifurcatedDrop<MemSegBuf>) drop).unwrap();
-                unsafeExchangeDrop(drop);
+                unsafeSetDrop(drop);
             } else {
                 alloc.recoverMemory(recoverableMemory());
             }
@@ -345,7 +345,8 @@ class MemSegBuf extends RcSupport<Buf, MemSegBuf> implements Buf {
         if (drop instanceof BifurcatedDrop) {
             ((BifurcatedDrop<?>) drop).increment();
         } else {
-            drop = unsafeExchangeDrop(new BifurcatedDrop<MemSegBuf>(new MemSegBuf(seg, drop, alloc), drop));
+            drop = new BifurcatedDrop<MemSegBuf>(new MemSegBuf(seg, drop, alloc), drop);
+            unsafeSetDrop(drop);
         }
         var bifurcatedSeg = seg.asSlice(0, woff);
         var bifurcatedBuf = new MemSegBuf(bifurcatedSeg, drop, alloc);

--- a/src/test/java/io/netty/buffer/api/BufRefTest.java
+++ b/src/test/java/io/netty/buffer/api/BufRefTest.java
@@ -60,7 +60,7 @@ class BufRefTest {
             assertThat(ref.contents().readInt()).isEqualTo(42);
 
             try (Buf buf = allocator.allocate(8)) {
-                ref.replaceVolatile(buf); // Pass replacement directly.
+                ref.replace(buf); // Pass replacement directly.
             }
 
             assertThrows(IllegalStateException.class, () -> orig.writeInt(32));
@@ -84,7 +84,7 @@ class BufRefTest {
             assertThat(ref.contents().readInt()).isEqualTo(42);
 
             try (Buf buf = allocator.allocate(8)) {
-                ref.replaceVolatile(buf.send()); // Pass replacement via send().
+                ref.replace(buf.send()); // Pass replacement via send().
             }
 
             assertThrows(IllegalStateException.class, () -> orig.writeInt(32));

--- a/src/test/java/io/netty/buffer/api/BufRefTest.java
+++ b/src/test/java/io/netty/buffer/api/BufRefTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BufRefTest {
+    @Test
+    public void closingBufRefMustCloseOwnedBuf() {
+        try (Allocator allocator = Allocator.heap()) {
+            BufRef ref;
+            try (Buf b = allocator.allocate(8)) {
+                ref = new BufRef(b);
+            }
+            ref.contents().writeInt(42);
+            assertThat(ref.contents().readInt()).isEqualTo(42);
+            ref.close();
+            assertThrows(IllegalStateException.class, () -> ref.contents().writeInt(32));
+        }
+    }
+
+    @Test
+    public void closingBufRefMustCloseOwnedBufFromSend() {
+        try (Allocator allocator = Allocator.heap();
+             Buf buf = allocator.allocate(8)) {
+            BufRef ref = new BufRef(buf.send());
+            ref.contents().writeInt(42);
+            assertThat(ref.contents().readInt()).isEqualTo(42);
+            ref.close();
+            assertThrows(IllegalStateException.class, () -> ref.contents().writeInt(32));
+        }
+    }
+
+    @Test
+    public void mustCloseOwnedBufferWhenReplaced() {
+        try (Allocator allocator = Allocator.heap()) {
+            Buf orig;
+            BufRef ref;
+            try (Buf buf = allocator.allocate(8)) {
+                ref = new BufRef(orig = buf);
+            }
+
+            orig.writeInt(42);
+            assertThat(ref.contents().readInt()).isEqualTo(42);
+
+            try (Buf buf = allocator.allocate(8)) {
+                ref.replaceVolatile(buf); // Pass replacement directly.
+            }
+
+            assertThrows(IllegalStateException.class, () -> orig.writeInt(32));
+            ref.contents().writeInt(42);
+            assertThat(ref.contents().readInt()).isEqualTo(42);
+            ref.close();
+            assertThrows(IllegalStateException.class, () -> ref.contents().writeInt(32));
+        }
+    }
+
+    @Test
+    public void mustCloseOwnedBufferWhenReplacedFromSend() {
+        try (Allocator allocator = Allocator.heap()) {
+            Buf orig;
+            BufRef ref;
+            try (Buf buf = allocator.allocate(8)) {
+                ref = new BufRef(orig = buf);
+            }
+
+            orig.writeInt(42);
+            assertThat(ref.contents().readInt()).isEqualTo(42);
+
+            try (Buf buf = allocator.allocate(8)) {
+                ref.replaceVolatile(buf.send()); // Pass replacement via send().
+            }
+
+            assertThrows(IllegalStateException.class, () -> orig.writeInt(32));
+            ref.contents().writeInt(42);
+            assertThat(ref.contents().readInt()).isEqualTo(42);
+            ref.close();
+            assertThrows(IllegalStateException.class, () -> ref.contents().writeInt(32));
+        }
+    }
+
+    @Test
+    public void sendingRefMustSendBuffer() {
+        try (Allocator allocator = Allocator.heap();
+             BufRef refA = new BufRef(allocator.allocate(8).send())) {
+            refA.contents().writeInt(42);
+            var send = refA.send();
+            assertThrows(IllegalStateException.class, () -> refA.contents().readInt());
+            try (BufRef refB = send.receive()) {
+                assertThat(refB.contents().readInt()).isEqualTo(42);
+            }
+        }
+    }
+}

--- a/src/test/java/io/netty/buffer/api/BufTest.java
+++ b/src/test/java/io/netty/buffer/api/BufTest.java
@@ -370,6 +370,112 @@ public class BufTest {
     }
 
     @ParameterizedTest
+    @MethodSource("nonSliceAllocators")
+    public void originalBufferMustNotBeAccessibleAfterSend(Fixture fixture) {
+        try (Allocator allocator = fixture.createAllocator();
+             Buf orig = allocator.allocate(24)) {
+            orig.writeLong(42);
+            var send = orig.send();
+            verifyInaccessible(orig);
+            try (Buf receive = send.receive()) {
+                assertEquals(42, receive.readInt());
+            }
+        }
+    }
+
+    private void verifyInaccessible(Buf buf) {
+        assertThrows(IllegalStateException.class, () -> buf.readByte());
+        assertThrows(IllegalStateException.class, () -> buf.readUnsignedByte());
+        assertThrows(IllegalStateException.class, () -> buf.readChar());
+        assertThrows(IllegalStateException.class, () -> buf.readShort());
+        assertThrows(IllegalStateException.class, () -> buf.readUnsignedShort());
+        assertThrows(IllegalStateException.class, () -> buf.readMedium());
+        assertThrows(IllegalStateException.class, () -> buf.readUnsignedMedium());
+        assertThrows(IllegalStateException.class, () -> buf.readInt());
+        assertThrows(IllegalStateException.class, () -> buf.readUnsignedInt());
+        assertThrows(IllegalStateException.class, () -> buf.readFloat());
+        assertThrows(IllegalStateException.class, () -> buf.readLong());
+        assertThrows(IllegalStateException.class, () -> buf.readDouble());
+        assertThrows(IllegalStateException.class, () -> buf.getByte(0));
+        assertThrows(IllegalStateException.class, () -> buf.getUnsignedByte(0));
+        assertThrows(IllegalStateException.class, () -> buf.getChar(0));
+        assertThrows(IllegalStateException.class, () -> buf.getShort(0));
+        assertThrows(IllegalStateException.class, () -> buf.getUnsignedShort(0));
+        assertThrows(IllegalStateException.class, () -> buf.getMedium(0));
+        assertThrows(IllegalStateException.class, () -> buf.getUnsignedMedium(0));
+        assertThrows(IllegalStateException.class, () -> buf.getInt(0));
+        assertThrows(IllegalStateException.class, () -> buf.getUnsignedInt(0));
+        assertThrows(IllegalStateException.class, () -> buf.getFloat(0));
+        assertThrows(IllegalStateException.class, () -> buf.getLong(0));
+        assertThrows(IllegalStateException.class, () -> buf.getDouble(0));
+        assertThrows(IllegalStateException.class, () -> buf.writeByte((byte) 32));
+        assertThrows(IllegalStateException.class, () -> buf.writeUnsignedByte(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeChar('3'));
+        assertThrows(IllegalStateException.class, () -> buf.writeShort((short) 32));
+        assertThrows(IllegalStateException.class, () -> buf.writeUnsignedShort(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeMedium(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeUnsignedMedium(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeInt(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeUnsignedInt(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeFloat(3.2f));
+        assertThrows(IllegalStateException.class, () -> buf.writeLong(32));
+        assertThrows(IllegalStateException.class, () -> buf.writeDouble(32));
+        assertThrows(IllegalStateException.class, () -> buf.setByte(0, (byte) 32));
+        assertThrows(IllegalStateException.class, () -> buf.setUnsignedByte(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setChar(0, '3'));
+        assertThrows(IllegalStateException.class, () -> buf.setShort(0, (short) 32));
+        assertThrows(IllegalStateException.class, () -> buf.setUnsignedShort(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setMedium(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setUnsignedMedium(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setInt(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setUnsignedInt(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setFloat(0, 3.2f));
+        assertThrows(IllegalStateException.class, () -> buf.setLong(0, 32));
+        assertThrows(IllegalStateException.class, () -> buf.setDouble(0, 32));
+
+        assertThrows(IllegalStateException.class, () -> buf.ensureWritable(1));
+        try (Allocator allocator = Allocator.heap();
+             Buf target = allocator.allocate(24)) {
+            assertThrows(IllegalStateException.class, () -> buf.copyInto(0, target, 0, 1));
+            if (Allocator.isComposite(buf)) {
+                assertThrows(IllegalStateException.class, () -> Allocator.extend(buf, target));
+            }
+        }
+        assertThrows(IllegalStateException.class, () -> buf.bifurcate());
+        assertThrows(IllegalStateException.class, () -> buf.send());
+        assertThrows(IllegalStateException.class, () -> buf.acquire());
+        assertThrows(IllegalStateException.class, () -> buf.slice());
+        assertThrows(IllegalStateException.class, () -> buf.fill((byte) 0));
+        assertThrows(IllegalStateException.class, () -> buf.openCursor());
+        assertThrows(IllegalStateException.class, () -> buf.openCursor(0, 0));
+        assertThrows(IllegalStateException.class, () -> buf.openReverseCursor());
+        assertThrows(IllegalStateException.class, () -> buf.openReverseCursor(0, 0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonSliceAllocators")
+    public void cannotSendMoreThanOnce(Fixture fixture) {
+        try (Allocator allocator = fixture.createAllocator();
+             Buf buf = allocator.allocate(8)) {
+            var send = buf.send();
+            var exc = assertThrows(IllegalStateException.class, () -> buf.send());
+            send.receive().close();
+            assertThat(exc).hasMessageContaining("Cannot send()");
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("allocators")
+    public void bufferShouldNotBeAccessibleAfterClose(Fixture fixture) {
+        try (Allocator allocator = fixture.createAllocator()) {
+            Buf buf = allocator.allocate(24);
+            buf.writeLong(42);
+            buf.close();
+            verifyInaccessible(buf);
+        }
+    }
+
+    @ParameterizedTest
     @MethodSource("initialAllocators")
     void mustThrowWhenAllocatingZeroSizedBuffer(Fixture fixture) {
         try (Allocator allocator = fixture.createAllocator()) {
@@ -1509,6 +1615,7 @@ public class BufTest {
             assertThat(buf.writableBytes()).isEqualTo(0);
             buf.ensureWritable(8);
             assertThat(buf.writableBytes()).isGreaterThanOrEqualTo(8);
+            assertThat(buf.capacity()).isGreaterThanOrEqualTo(16);
             buf.writeLong(0xA1A2A3A4A5A6A7A8L);
             assertThat(buf.readableBytes()).isEqualTo(16);
             assertThat(buf.readLong()).isEqualTo(0x0102030405060708L);
@@ -1540,6 +1647,7 @@ public class BufTest {
              Buf buf = allocator.allocate(4)) {
             buf.ensureWritable(8);
             assertThat(buf.writableBytes()).isGreaterThanOrEqualTo(8);
+            assertThat(buf.capacity()).isGreaterThanOrEqualTo(8);
             buf.writeLong(0x0102030405060708L);
             try (Buf slice = buf.slice()) {
                 assertEquals(0x0102030405060708L, slice.readLong());
@@ -1839,6 +1947,15 @@ public class BufTest {
                     assertThat(composite.readerOffset()).isEqualTo(4);
                 }
             }
+        }
+    }
+
+    @Test
+    public void composeMustThrowWhenBuffersHaveMismatchedByteOrder() {
+        try (Allocator allocator = Allocator.heap();
+             Buf a = allocator.allocate(4, ByteOrder.BIG_ENDIAN);
+             Buf b = allocator.allocate(4, ByteOrder.LITTLE_ENDIAN)) {
+            assertThrows(IllegalArgumentException.class, () -> allocator.compose(a, b));
         }
     }
 

--- a/src/test/java/io/netty/buffer/api/ScopeTest.java
+++ b/src/test/java/io/netty/buffer/api/ScopeTest.java
@@ -15,17 +15,17 @@
  */
 package io.netty.buffer.api;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScopeTest {
     @Test
-    public void scopeMustCloseContainedRcsInReverseInsertOrder() {
+    void scopeMustCloseContainedRcsInReverseInsertOrder() {
         ArrayList<Integer> closeOrder = new ArrayList<>();
         try (Scope scope = new Scope()) {
             scope.add(new SomeRc(new OrderingDrop(1, closeOrder)));


### PR DESCRIPTION
Motivation:
There are many use cases where other objects will have fields that are buffers.
Since buffers are reference counted, their life cycle needs to be managed carefully.

Modification:
Add the abstract BufHolder, and the concrete sub-class BufRef, as neat building blocks for building other classes that contain field references to buffers.

The behaviours of closed/sent buffers have also been specified in tests, and tightened up in the code.

Result:
It is now easier to create classes/objects that wrap buffers.