### PR TITLE
Buffer Compaction

### DIFF
--- a/src/main/java/io/netty/buffer/api/Buf.java
+++ b/src/main/java/io/netty/buffer/api/Buf.java
@@ -417,4 +417,11 @@ public interface Buf extends Rc<Buf>, BufAccessors {
      * @return A new buffer with independent and exclusive ownership over the read and readable bytes from this buffer.
      */
     Buf bifurcate();
+
+    /**
+     * Discards the read bytes, and moves the buffer contents to the beginning of the buffer.
+     *
+     * The buffer must be {@linkplain #isOwned() owned}, or an exception will be thrown.
+     */
+    void compact();
 }

--- a/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
+++ b/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
@@ -384,6 +384,29 @@ class MemSegBuf extends RcSupport<Buf, MemSegBuf> implements Buf {
         return bifurcatedBuf;
     }
 
+    @Override
+    public void compact() {
+        if (!isOwned()) {
+            throw new IllegalStateException("Buffer must be owned in order to compact.");
+        }
+        int distance = roff;
+        if (distance == 0) {
+            return;
+        }
+        int pos = 0;
+        var cursor = openCursor();
+        while (cursor.readLong()) {
+            setLongAtOffset(seg, pos, ByteOrder.BIG_ENDIAN, cursor.getLong());
+            pos += Long.BYTES;
+        }
+        while (cursor.readByte()) {
+            setByteAtOffset(seg, pos, cursor.getByte());
+            pos++;
+        }
+        roff -= distance;
+        woff -= distance;
+    }
+
     // <editor-fold defaultstate="collapsed" desc="Primitive accessors implementation.">
     @Override
     public byte readByte() {

--- a/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
+++ b/src/main/java/io/netty/buffer/api/memseg/MemSegBuf.java
@@ -393,16 +393,7 @@ class MemSegBuf extends RcSupport<Buf, MemSegBuf> implements Buf {
         if (distance == 0) {
             return;
         }
-        int pos = 0;
-        var cursor = openCursor();
-        while (cursor.readLong()) {
-            setLongAtOffset(seg, pos, ByteOrder.BIG_ENDIAN, cursor.getLong());
-            pos += Long.BYTES;
-        }
-        while (cursor.readByte()) {
-            setByteAtOffset(seg, pos, cursor.getByte());
-            pos++;
-        }
+        seg.copyFrom(seg.asSlice(roff, woff - roff));
         roff -= distance;
         woff -= distance;
     }


### PR DESCRIPTION
Adds a `compact()` method, and an `ensureWritable()` overload which may allow compaction.