### PR TITLE
Add a benchmark that explore the overhead of always attaching a cleaner to buffers

### DIFF
--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
@@ -44,6 +44,7 @@ public class MemorySegmentClosedByCleanerBenchmark {
     private static final Allocator direct = Allocator.direct();
     private static final Allocator withCleaner = Allocator.directWithCleaner();
     private static final Allocator directPooled = Allocator.pooledDirect();
+    private static final Allocator pooledWithCleaner = Allocator.pooledDirectWithCleaner();
 
     @Param({"heavy", "light"})
     public String workload;
@@ -77,6 +78,18 @@ public class MemorySegmentClosedByCleanerBenchmark {
     @Benchmark
     public Buf cleanerClose() throws Exception {
         return process(withCleaner.allocate(256));
+    }
+
+    @Benchmark
+    public Buf cleanerClosePooled() throws Exception {
+        return process(pooledWithCleaner.allocate(256));
+    }
+
+    @Benchmark
+    public Buf pooledWithCleanerExplicitClose() throws Exception {
+        try (Buf buf = pooledWithCleaner.allocate(256)) {
+            return process(buf);
+        }
     }
 
     private Buf process(Buf buffer) throws Exception {


### PR DESCRIPTION
Looks like the overhead is not too bad, so I think we can just always do that:

```
Benchmark                       (workload)  Mode  Cnt  Score   Error  Units
explicitPooledClose                  light  avgt  150  1,094 ± 0,017  us/op
pooledWithCleanerExplicitClose       light  avgt  150  1,181 ± 0,009  us/op
```

This PR is baselined on #18 