### PR TITLE
Remove thread-confinement of Buffers 

### DIFF
--- a/src/main/java/io/netty/buffer/api/ManagedAllocator.java
+++ b/src/main/java/io/netty/buffer/api/ManagedAllocator.java
@@ -31,13 +31,13 @@ class ManagedAllocator implements Allocator, AllocatorControl {
     @Override
     public Buf allocate(int size) {
         Allocator.checkSize(size);
-        return manager.allocateConfined(this, size, manager.drop(), cleaner);
+        return manager.allocateShared(this, size, manager.drop(), cleaner);
     }
 
     @Override
     public Object allocateUntethered(Buf originator, int size) {
         Allocator.checkSize(size);
-        var buf = manager.allocateConfined(this, size, NO_OP_DROP, null);
+        var buf = manager.allocateShared(this, size, NO_OP_DROP, null);
         return manager.unwrapRecoverableMemory(buf);
     }
 

--- a/src/main/java/io/netty/buffer/api/memseg/HeapMemorySegmentManager.java
+++ b/src/main/java/io/netty/buffer/api/memseg/HeapMemorySegmentManager.java
@@ -15,6 +15,8 @@
  */
 package io.netty.buffer.api.memseg;
 
+import io.netty.buffer.api.Buf;
+import io.netty.buffer.api.Drop;
 import jdk.incubator.foreign.MemorySegment;
 
 public class HeapMemorySegmentManager extends AbstractMemorySegmentManager {
@@ -26,5 +28,16 @@ public class HeapMemorySegmentManager extends AbstractMemorySegmentManager {
     @Override
     protected MemorySegment createSegment(long size) {
         return MemorySegment.ofArray(new byte[Math.toIntExact(size)]);
+    }
+
+    @Override
+    public Drop<Buf> drop() {
+        return convert(buf -> buf.makeInaccessible());
+    }
+
+    @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
+    private static Drop<Buf> convert(Drop<MemSegBuf> drop) {
+        Drop<?> tmp = drop;
+        return (Drop<Buf>) tmp;
     }
 }

--- a/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
+++ b/src/test/java/io/netty/buffer/api/benchmarks/MemorySegmentClosedByCleanerBenchmark.java
@@ -34,13 +34,15 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-@Warmup(iterations = 30, time = 1)
-@Measurement(iterations = 30, time = 1)
+@Warmup(iterations = 15, time = 1)
+@Measurement(iterations = 15, time = 1)
 @Fork(value = 5, jvmArgsAppend = { "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints" })
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 public class MemorySegmentClosedByCleanerBenchmark {
+    private static final Allocator heap = Allocator.heap();
+    private static final Allocator heapPooled = Allocator.pooledHeap();
     private static final Allocator direct = Allocator.direct();
     private static final Allocator directPooled = Allocator.pooledDirect();
 
@@ -60,14 +62,28 @@ public class MemorySegmentClosedByCleanerBenchmark {
     }
 
     @Benchmark
-    public Buf explicitClose() throws Exception {
+    public Buf explicitCloseHeap() throws Exception {
+        try (Buf buf = process(heap.allocate(256))) {
+            return buf;
+        }
+    }
+
+    @Benchmark
+    public Buf explicitPooledCloseHeap() throws Exception {
+        try (Buf buf = process(heapPooled.allocate(256))) {
+            return buf;
+        }
+    }
+
+    @Benchmark
+    public Buf explicitCloseDirect() throws Exception {
         try (Buf buf = process(direct.allocate(256))) {
             return buf;
         }
     }
 
     @Benchmark
-    public Buf explicitPooledClose() throws Exception {
+    public Buf explicitPooledCloseDirect() throws Exception {
         try (Buf buf = process(directPooled.allocate(256))) {
             return buf;
         }


### PR DESCRIPTION
Motivation:
Thread-confinement ends up being too confusing to code for, and also prevents some legitimate use cases.
Additionally, thread-confinement exposed implementation specific behavioural differences of buffers, where we would ideally like all buffers to always behave the same, regardless of implementation.

Modification:
All MemorySegment based buffers now always use shared segments.
For heap-based segments, we avoid the overhead associated with the closing of shared segments, by just not closing them, and instead just leave the whole thing for the GC to deal with.

Result:
Buffers can now always be accessed from multiple different threads at the same time.

Latest results from the `MemorySegmentClosedByCleanerBenchmark` benchmark:

```
Benchmark                                                        (workload)  Mode  Cnt   Score   Error  Units
MemorySegmentClosedByCleanerBenchmark.explicitCloseDirect             heavy  avgt   75  56,055 ± 0,586  us/op
MemorySegmentClosedByCleanerBenchmark.explicitCloseDirect             light  avgt   75  40,560 ± 0,536  us/op
MemorySegmentClosedByCleanerBenchmark.explicitCloseHeap               heavy  avgt   75  36,593 ± 1,117  us/op
MemorySegmentClosedByCleanerBenchmark.explicitCloseHeap               light  avgt   75  21,762 ± 0,732  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledCloseDirect       heavy  avgt   75  12,488 ± 0,271  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledCloseDirect       light  avgt   75   1,155 ± 0,023  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledCloseHeap         heavy  avgt   75  12,800 ± 0,260  us/op
MemorySegmentClosedByCleanerBenchmark.explicitPooledCloseHeap         light  avgt   75   1,251 ± 0,015  us/op
```