### PR TITLE
Add support for read-only buffers

### DIFF
--- a/src/main/java/io/netty/buffer/api/Allocator.java
+++ b/src/main/java/io/netty/buffer/api/Allocator.java
@@ -70,7 +70,7 @@ public interface Allocator extends AutoCloseable {
      * <pre>{@code
      *     try (Buf a = allocator.allocate(size);
      *          Buf b = allocator.allocate(size)) {
-     *         return Buf.compose(a, b); // Reference counts for 'a' and 'b' incremented here.
+     *         return allocator.compose(a, b); // Reference counts for 'a' and 'b' incremented here.
      *     } // Reference count for 'a' and 'b' decremented here; composite buffer now holds the last references.
      * }</pre>
      * <p>

--- a/src/main/java/io/netty/buffer/api/Buf.java
+++ b/src/main/java/io/netty/buffer/api/Buf.java
@@ -154,6 +154,7 @@ public interface Buf extends Rc<Buf>, BufAccessors {
      * @return This Buf.
      * @throws IndexOutOfBoundsException if the specified {@code offset} is less than the current
      * {@link #readerOffset()} or greater than {@link #capacity()}.
+     * @throws IllegalStateException if this buffer is {@linkplain #readOnly() read-only}.
      */
     Buf writerOffset(int offset);
 
@@ -178,6 +179,7 @@ public interface Buf extends Rc<Buf>, BufAccessors {
      *
      * @param value The byte value to write at every position in the buffer.
      * @return This Buf.
+     * @throws IllegalStateException if this buffer is {@linkplain #readOnly() read-only}.
      */
     Buf fill(byte value);
 
@@ -186,6 +188,20 @@ public interface Buf extends Rc<Buf>, BufAccessors {
      * @return The native memory address, if any, otherwise 0.
      */
     long getNativeAddress();
+
+    /**
+     * Set the read-only state of this buffer.
+     *
+     * @return this buffer.
+     */
+    Buf readOnly(boolean readOnly);
+
+    /**
+     * Query if this buffer is read-only or not.
+     *
+     * @return {@code true} if this buffer is read-only, {@code false} otherwise.
+     */
+    boolean readOnly();
 
     /**
      * Returns a slice of this buffer's readable bytes.
@@ -371,8 +387,8 @@ public interface Buf extends Rc<Buf>, BufAccessors {
      * {@code false}.
      *
      * @param size The requested number of bytes of space that should be available for writing.
-     * @throws IllegalStateException if this buffer is not in an owned state.
-     * That is, if {@link #isOwned()} is {@code false}.
+     * @throws IllegalStateException if this buffer is not in an {@linkplain #isOwned() owned} state,
+     * or is {@linkplain #readOnly() read-only}.
      */
     default void ensureWritable(int size) {
         ensureWritable(size, true);
@@ -410,8 +426,8 @@ public interface Buf extends Rc<Buf>, BufAccessors {
      * @param allowCompaction {@code true} if the method is allowed to modify the
      *                                   {@linkplain #readerOffset() reader offset} and
      *                                   {@linkplain #writerOffset() writer offset}, otherwise {@code false}.
-     * @throws IllegalStateException if this buffer is not in an owned state.
-     * That is, if {@link #isOwned()} is {@code false}.
+     * @throws IllegalStateException if this buffer is not in an {@linkplain #isOwned() owned} state,
+     *      * or is {@linkplain #readOnly() read-only}.
      */
     void ensureWritable(int size, boolean allowCompaction);
 
@@ -462,7 +478,8 @@ public interface Buf extends Rc<Buf>, BufAccessors {
     /**
      * Discards the read bytes, and moves the buffer contents to the beginning of the buffer.
      *
-     * The buffer must be {@linkplain #isOwned() owned}, or an exception will be thrown.
+     * @throws IllegalStateException if this buffer is not in an {@linkplain #isOwned() owned} state,
+     * or is {@linkplain #readOnly() read-only}.
      */
     void compact();
 }

--- a/src/main/java/io/netty/buffer/api/SizeClassedMemoryPool.java
+++ b/src/main/java/io/netty/buffer/api/SizeClassedMemoryPool.java
@@ -43,7 +43,11 @@ class SizeClassedMemoryPool implements Allocator, AllocatorControl, Drop<Buf> {
         var sizeClassPool = getSizeClassPool(size);
         Send<Buf> send = sizeClassPool.poll();
         if (send != null) {
-            return send.receive().reset().fill((byte) 0).order(ByteOrder.nativeOrder());
+            return send.receive()
+                       .reset()
+                       .readOnly(false)
+                       .fill((byte) 0)
+                       .order(ByteOrder.nativeOrder());
         }
         return createBuf(size, getDrop());
     }


### PR DESCRIPTION
Motivation:
There are cases where you want a buffer to be "constant."
Buffers are inherently mutable, but it's possible to block off write access to the buffer contents.
This doesn't make it completely safe to share the buffer across multiple threads, but it does catch most races that could occur.

Modification:
Add a method to Buf for toggling read-only mode.
When a buffer is read-only, the write accessors throw exceptions when called.
In the MemSegBuf, this is implemented by having separate read and write references to the underlying memory segment.
In a read-only buffer, the write reference is redirected to point to a closed memory segment, thus preventing all writes to the memory backing the buffer.

Result:
It is now possible to make buffers read-only.
Note, however, that it is also possible to toggle a read-only buffer back to writable.
We need that in order for buffer pools to be able to fully reset the state of a buffer, regardless of the buffer implementation.