### PR TITLE
Introduce Deref abstraction

### DIFF
--- a/src/main/java/io/netty/buffer/api/Allocator.java
+++ b/src/main/java/io/netty/buffer/api/Allocator.java
@@ -107,7 +107,7 @@ public interface Allocator extends AutoCloseable {
      * @return A buffer composed of, and backed by, the given buffers.
      * @throws IllegalArgumentException if the given buffers have an inconsistent {@linkplain Buf#order() byte order}.
      */
-    default Buf compose(Buf... bufs) {
+    default Buf compose(Deref<Buf>... bufs) {
         return new CompositeBuf(this, bufs);
     }
 
@@ -117,8 +117,8 @@ public interface Allocator extends AutoCloseable {
      * the composite buffer was created.
      * The composite buffer is modified in-place.
      *
-     * @see #compose(Buf...)
-     * @param composite The composite buffer (from a prior {@link #compose(Buf...)} call) to extend with the given
+     * @see #compose(Deref...)
+     * @param composite The composite buffer (from a prior {@link #compose(Deref...)} call) to extend with the given
      *                 extension buffer.
      * @param extension The buffer to extend the composite buffer with.
      */
@@ -133,9 +133,9 @@ public interface Allocator extends AutoCloseable {
     }
 
     /**
-     * Check if the given buffer is a {@linkplain #compose(Buf...) composite} buffer or not.
+     * Check if the given buffer is a {@linkplain #compose(Deref...) composite} buffer or not.
      * @param composite The buffer to check.
-     * @return {@code true} if the given buffer was created with {@link #compose(Buf...)}, {@code false} otherwise.
+     * @return {@code true} if the given buffer was created with {@link #compose(Deref...)}, {@code false} otherwise.
      */
     static boolean isComposite(Buf composite) {
         return composite.getClass() == CompositeBuf.class;

--- a/src/main/java/io/netty/buffer/api/Buf.java
+++ b/src/main/java/io/netty/buffer/api/Buf.java
@@ -70,7 +70,7 @@ import java.nio.ByteOrder;
  * To send a buffer to another thread, the buffer must not have any outstanding borrows.
  * That is to say, all {@linkplain #acquire() acquires} must have been paired with a {@link #close()};
  * all {@linkplain #slice() slices} must have been closed.
- * And if this buffer is a constituent of a {@linkplain Allocator#compose(Buf...) composite buffer},
+ * And if this buffer is a constituent of a {@linkplain Allocator#compose(Deref...) composite buffer},
  * then that composite buffer must be closed.
  * And if this buffer is itself a composite buffer, then it must own all of its constituent buffers.
  * The {@link #isOwned()} method can be used on any buffer to check if it can be sent or not.
@@ -438,6 +438,8 @@ public interface Buf extends Rc<Buf>, BufAccessors {
 
     /**
      * Split the buffer into two, at the {@linkplain #writerOffset() write offset} position.
+     * <p>
+     * The buffer must be in {@linkplain #isOwned() an owned state}, or an exception will be thrown.
      * <p>
      * The region of this buffer that contain the read and readable bytes, will be captured and returned in a new
      * buffer, that will hold its own ownership of that region. This allows the returned buffer to be indepentently

--- a/src/main/java/io/netty/buffer/api/BufHolder.java
+++ b/src/main/java/io/netty/buffer/api/BufHolder.java
@@ -83,10 +83,10 @@ public abstract class BufHolder<T extends BufHolder<T>> implements Rc<T> {
         return buf.countBorrows();
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public Send<T> send() {
-        var send = buf.send();
-        return () -> receive(send.receive());
+        return buf.send().map((Class<T>) getClass(), this::receive);
     }
 
     /**

--- a/src/main/java/io/netty/buffer/api/ComponentProcessor.java
+++ b/src/main/java/io/netty/buffer/api/ComponentProcessor.java
@@ -121,6 +121,7 @@ public interface ComponentProcessor {
          * @return A new {@link ByteBuffer}, with its own position and limit, for this memory component.
          */
         ByteBuffer readableBuffer();
+        // todo for Unsafe-based impl, DBB.attachment needs to keep underlying memory alive
     }
 
     /**

--- a/src/main/java/io/netty/buffer/api/Deref.java
+++ b/src/main/java/io/netty/buffer/api/Deref.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.buffer.api;
+
+import java.util.function.Supplier;
+
+/**
+ * A Deref provides the capability to acquire a reference to a {@linkplain Rc reference counted} object.
+ * <p>
+ * <strong>Note:</strong> Callers must ensure that they close any references they obtain.
+ * <p>
+ * Deref itself does not specify if a reference can be obtained more than once.
+ * For instance, any {@link Send} object is also a {@code Deref}, but the reference can only be acquired once.
+ * Meanwhile, {@link Rc} objects are themselves their own {@code Derefs}, and permit references to be acquired multiple
+ * times.
+ *
+ * @param <T> The concrete type of reference counted object that can be obtained.
+ */
+public interface Deref<T extends Rc<T>> extends Supplier<T> {
+    /**
+     * Acquire a reference to the reference counted object.
+     * <p>
+     * <strong>Note:</strong> This call increments the reference count of the acquired object, and must be paired with
+     * a {@link Rc#close()} call.
+     * Using a try-with-resources clause is the easiest way to ensure this.
+     *
+     * @return A reference to the reference counted object.
+     */
+    @Override
+    T get();
+
+    /**
+     * Determine if the object in this {@code Deref} is an instance of the given class.
+     *
+     * @param cls The type to check.
+     * @return {@code true} if the object in this {@code Deref} can be assigned fields or variables of the given type.
+     */
+    boolean isInstanceOf(Class<?> cls);
+}

--- a/src/main/java/io/netty/buffer/api/Rc.java
+++ b/src/main/java/io/netty/buffer/api/Rc.java
@@ -26,7 +26,7 @@ package io.netty.buffer.api;
  *
  * @param <I> The concrete subtype.
  */
-public interface Rc<I extends Rc<I>> extends AutoCloseable {
+public interface Rc<I extends Rc<I>> extends AutoCloseable, Deref<I> {
     /**
      * Increment the reference count.
      * <p>
@@ -35,6 +35,16 @@ public interface Rc<I extends Rc<I>> extends AutoCloseable {
      * @return This Rc instance.
      */
     I acquire();
+
+    @Override
+    default I get() {
+        return acquire();
+    }
+
+    @Override
+    default boolean isInstanceOf(Class<?> cls) {
+        return cls.isInstance(this);
+    }
 
     /**
      * Decrement the reference count, and despose of the resource if the last reference is closed.

--- a/src/main/java/io/netty/buffer/api/RcSupport.java
+++ b/src/main/java/io/netty/buffer/api/RcSupport.java
@@ -79,7 +79,7 @@ public abstract class RcSupport<I extends Rc<I>, T extends RcSupport<I, T>> impl
         }
         var owned = prepareSend();
         acquires = -2; // Close without dropping. This also ignore future double-free attempts.
-        return new TransferSend<I, T>(owned, drop);
+        return new TransferSend<I, T>(owned, drop, getClass());
     }
 
     /**

--- a/src/test/java/io/netty/buffer/api/BufRefTest.java
+++ b/src/test/java/io/netty/buffer/api/BufRefTest.java
@@ -100,7 +100,7 @@ class BufRefTest {
         try (Allocator allocator = Allocator.heap();
              BufRef refA = new BufRef(allocator.allocate(8).send())) {
             refA.contents().writeInt(42);
-            var send = refA.send();
+            Send<BufRef> send = refA.send();
             assertThrows(IllegalStateException.class, () -> refA.contents().readInt());
             try (BufRef refB = send.receive()) {
                 assertThat(refB.contents().readInt()).isEqualTo(42);

--- a/src/test/java/io/netty/buffer/api/examples/AsyncExample.java
+++ b/src/test/java/io/netty/buffer/api/examples/AsyncExample.java
@@ -18,6 +18,7 @@ package io.netty.buffer.api.examples;
 import io.netty.buffer.api.Allocator;
 import io.netty.buffer.api.Buf;
 
+import static java.lang.System.out;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public final class AsyncExample {
@@ -33,9 +34,9 @@ public final class AsyncExample {
                 }
             }).thenAcceptAsync(send -> {
                 try (Buf buf = send.receive()) {
-                    System.out.println("First thread id was " + buf.readLong());
-                    System.out.println("Then sent to " + buf.readLong());
-                    System.out.println("And now in thread " + threadId());
+                    out.println("First thread id was " + buf.readLong());
+                    out.println("Then sent to " + buf.readLong());
+                    out.println("And now in thread " + threadId());
                 }
             }).get();
         }


### PR DESCRIPTION
Motivation:
Sometimes, we wish to operate on both buffers and anything that can produce a buffer.
For instance, when making a composite buffer, we could compose either buffers or sends.

Modification:
Introduce a Deref interface, which is extended by both Rc and Send.
A Deref can be used to acquire an Rc instance, and in doing so will also acquire a reference to the Rc.
That is, dereferencing increases the reference count.
For Rc itself, this just delegates to Rc.acquire, while for Send it delegates to Send.receive, and can only be called once.
The Allocator.compose method has been changed to take Derefs.
This allows us to compose either Bufs or Sends of bufs.
Or a mix.
Extra care and caution has been added to the code, to make sure the reference counts are managed correctly when composing buffers, now that it's a more complicated operation.
A handful of convenience methods for working with Sends have also been added to the Send interface.

Result:
We can now build a composite buffer out of sends of buffers.