### PR TITLE
Make ReadableComponent expose ByteCursors

### DIFF
--- a/src/main/java/io/netty/buffer/api/ReadableComponent.java
+++ b/src/main/java/io/netty/buffer/api/ReadableComponent.java
@@ -72,5 +72,18 @@ public interface ReadableComponent {
      * @return A new {@link ByteBuffer}, with its own position and limit, for this memory component.
      */
     ByteBuffer readableBuffer();
+
+    /**
+     * Open a cursor to iterate the readable bytes of this component.
+     * Any offsets internal to the component are not modified by the cursor.
+     * <p>
+     * Care should be taken to ensure that the buffers lifetime extends beyond the cursor and the iteration, and that
+     * the internal offsets of the component (such as {@link Buffer#readerOffset()} and {@link Buffer#writerOffset()})
+     * are not modified while the iteration takes place. Otherwise unpredictable behaviour might result.
+     *
+     * @return A {@link ByteCursor} for iterating the readable bytes of this buffer.
+     * @see Buffer#openCursor()
+     */
+    ByteCursor openCursor();
     // todo for Unsafe-based impl, DBB.attachment needs to keep underlying memory alive
 }

--- a/src/main/java/io/netty/buffer/api/memseg/MemSegBuffer.java
+++ b/src/main/java/io/netty/buffer/api/memseg/MemSegBuffer.java
@@ -301,6 +301,11 @@ class MemSegBuffer extends RcSupport<Buffer, MemSegBuffer> implements Buffer, Re
     }
 
     @Override
+    public ByteCursor openCursor() {
+        return openCursor(readerOffset(), readableBytes());
+    }
+
+    @Override
     public ByteCursor openCursor(int fromOffset, int length) {
         if (seg == CLOSED_SEGMENT) {
             throw bufferIsClosed();
@@ -362,6 +367,12 @@ class MemSegBuffer extends RcSupport<Buffer, MemSegBuffer> implements Buffer, Re
                 return end - index;
             }
         };
+    }
+
+    @Override
+    public ByteCursor openReverseCursor() {
+        int woff = writerOffset();
+        return openReverseCursor(woff == 0? 0 : woff - 1, readableBytes());
     }
 
     @Override


### PR DESCRIPTION
Motivation:
Another way to process the readable data in a buffer.
This might be faster for composite buffers, since their byte cursors are a bit slower than the MemSegBuffer due to the indirections and more complicated logic.

Modification:
ReadableComponent now have an openCursor method.

Result:
It is now possible to process readable components with byte cursors.