### PR TITLE
Use the memaccess+abi branch of panama-foreign

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN dnf -y install file findutils unzip zip libXtst-devel libXt-devel libXrender
 
 # Build panama-foreign openjdk
 WORKDIR /home/build
-RUN git clone https://github.com/openjdk/panama-foreign.git panama-foreign
+RUN git clone --branch foreign-memaccess+abi https://github.com/openjdk/panama-foreign.git panama-foreign
 WORKDIR /home/build/panama-foreign
 RUN chmod +x configure
 RUN ./configure --with-debug-level=fastdebug \


### PR DESCRIPTION
Motivation:
The jextract branch is currently suffering from upstream compilation
errors.
And we don't need jextract - memaccess+abi is enough.

Modification:
Avoid checking out the jextract branch of panama by default, and instead
explicitly check out the foreign-memaccess+abi branch when we clone the
JDK.

Result:
Our build should now be able to proceed again.