### PR TITLE
Add a build step that uploads surefire test reports

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -43,8 +43,15 @@ jobs:
       # Run the make script
       - name: Make build
         run: make build
-
-      - uses: actions/upload-artifact@v2
+      - name: Publish Test Report
+        uses: scacap/action-surefire-report@v1.0.7
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/target/surefire-reports/TEST-*.xml'
+          commit: ${{ github.event.workflow_run.head_commit.id }}
+          check_name: Build test reports
+      - name: Upload build artefacts
+        uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         with:
           name: target


### PR DESCRIPTION
Motivation:
When a build fails, the number one priority is figuring out why.
Having surefire test reports readily available on the Github Actions page will make this easier.

Modification:
Add a build step that uploads surefire test reports and attaches them as a check to the PR.

Result:
Easier to diagnose test failures on PRs.