### PR TITLE
Rename Deref.isInstanceOf to referentIsInstanceOf

### DIFF
--- a/src/main/java/io/netty/buffer/api/Deref.java
+++ b/src/main/java/io/netty/buffer/api/Deref.java
@@ -48,5 +48,5 @@ public interface Deref<T extends Rc<T>> extends Supplier<T> {
      * @param cls The type to check.
      * @return {@code true} if the object in this {@code Deref} can be assigned fields or variables of the given type.
      */
-    boolean isInstanceOf(Class<?> cls);
+    boolean referentIsInstanceOf(Class<?> cls);
 }

--- a/src/main/java/io/netty/buffer/api/Rc.java
+++ b/src/main/java/io/netty/buffer/api/Rc.java
@@ -42,7 +42,7 @@ public interface Rc<I extends Rc<I>> extends AutoCloseable, Deref<I> {
     }
 
     @Override
-    default boolean isInstanceOf(Class<?> cls) {
+    default boolean referentIsInstanceOf(Class<?> cls) {
         return cls.isInstance(this);
     }
 

--- a/src/main/java/io/netty/buffer/api/Send.java
+++ b/src/main/java/io/netty/buffer/api/Send.java
@@ -56,7 +56,7 @@ public interface Send<T extends Rc<T>> extends Deref<T> {
             }
 
             @Override
-            public boolean isInstanceOf(Class<?> cls) {
+            public boolean referentIsInstanceOf(Class<?> cls) {
                 return cls.isAssignableFrom(concreteObjectType);
             }
 
@@ -67,6 +67,19 @@ public interface Send<T extends Rc<T>> extends Deref<T> {
                 }
             }
         };
+    }
+
+    /**
+     * Determine if the given candidate object is an instance of a {@link Send} from which an object of the given type
+     * can be received.
+     *
+     * @param type The type of object we wish to receive.
+     * @param candidate The candidate object that might be a {@link Send} of an object of the given type.
+     * @return {@code true} if the candidate object is a {@link Send} that would deliver an object of the given type,
+     * otherwise {@code false}.
+     */
+    static boolean isSendOf(Class<?> type, Object candidate) {
+        return candidate instanceof Send && ((Send<?>) candidate).referentIsInstanceOf(type);
     }
 
     /**

--- a/src/main/java/io/netty/buffer/api/TransferSend.java
+++ b/src/main/java/io/netty/buffer/api/TransferSend.java
@@ -55,7 +55,7 @@ class TransferSend<I extends Rc<I>, T extends Rc<I>> implements Send<I> {
     }
 
     @Override
-    public boolean isInstanceOf(Class<?> cls) {
+    public boolean referentIsInstanceOf(Class<?> cls) {
         return cls.isAssignableFrom(concreteType);
     }
 


### PR DESCRIPTION
Motivation:
Derefs are not necessarily their referents.
This is the case for Send, for instance.

Modification:
The Deref.isInstanceOf method is renamed to referentIsInstanceOf.
And a Send.isSendOf method has been added, that simplifies the check for sends, since it could be the case that one also needs to check if the object in question is also a Send instance.

Result:
Cleaner code that is easier to read, when working with Sends.

This fixes #46

Please take a look, @ejona86.