### PR TITLE
Make the build use less space on the CI host

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -57,3 +57,6 @@ jobs:
         with:
           name: artifacts
           path: target/
+      # Make room for the docker layer caching to package up layers
+      - name: Cleanup
+        run: rm -fr *

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Create Cache Key
         id: cache-key
         run: |
-          echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
+          echo "::set-output name=key::$(/bin/date -u "+%Y%U-2")"
         shell: bash
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ RUN curl https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-
 ENV PATH=/home/build/apache-maven-3.6.3/bin:$PATH
 
 # Prepare a snapshot of Netty 5
-RUN git clone -b master https://github.com/netty/netty.git netty
-WORKDIR /home/build/netty
-RUN mvn install -DskipTests -T1C -B -am
-WORKDIR /home/build
+RUN git clone --depth 1 -b master https://github.com/netty/netty.git netty \
+    && cd netty \
+    && mvn install -DskipTests -T1C -B -am \
+    && cd .. \
+    && rm -fr netty
 
 # Prepare our own build
 COPY pom.xml pom.xml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: image test dbg clean build
+.PHONY: image test dbg clean build rebuild
 .DEFAULT_GOAL := build
 
 image:


### PR DESCRIPTION
High space usage could cause the docker layer cache to fail while packaging the layers.