### PR TITLE
Add splitComponentsFloor and splitComponentsCeil

### DIFF
--- a/src/main/java/io/netty/buffer/api/Buffer.java
+++ b/src/main/java/io/netty/buffer/api/Buffer.java
@@ -607,7 +607,8 @@ public interface Buffer extends Rc<Buffer>, BufferAccessors {
      * See the <a href="#slice-split">Slice vs. Split</a> section for details on the difference between slice
      * and split.
      *
-     * @return A new buffer with independent and exclusive ownership over the read and readable bytes from this buffer.
+     * @return A new buffer with independent and exclusive ownership over the bytes from the beginning to the given
+     * offset of this buffer.
      */
     Buffer split(int splitOffset);
 


### PR DESCRIPTION
These methods make it possible to accurately split composite buffers at component boundaries, either by rounding the offset down or up to the nearest component boundary, respectively.

Composite buffers already support the split method, but it is hard for client code to predict precisely where component boundaries are placed inside composite buffers.
When split is used with an offset that does not land exactly on a component boundary, then the internal component that the offset lands on will also be split.
This may make it harder to precisely reason about memory life cycles and reuse.

This fixes #48 