### PR TITLE
Hide Rc.countBorrows

### DIFF
--- a/src/main/java/io/netty/buffer/api/BufferHolder.java
+++ b/src/main/java/io/netty/buffer/api/BufferHolder.java
@@ -78,11 +78,6 @@ public abstract class BufferHolder<T extends BufferHolder<T>> implements Rc<T> {
         return buf.isOwned();
     }
 
-    @Override
-    public int countBorrows() {
-        return buf.countBorrows();
-    }
-
     @SuppressWarnings("unchecked")
     @Override
     public Send<T> send() {

--- a/src/main/java/io/netty/buffer/api/Rc.java
+++ b/src/main/java/io/netty/buffer/api/Rc.java
@@ -70,15 +70,6 @@ public interface Rc<I extends Rc<I>> extends AutoCloseable {
     boolean isOwned();
 
     /**
-     * Count the number of borrows of this object.
-     * Note that even if the number of borrows is {@code 0}, this object might not be {@linkplain #isOwned() owned}
-     * because there could be other restrictions involved in ownership.
-     *
-     * @return The number of borrows, if any, of this object.
-     */
-    int countBorrows();
-
-    /**
      * Check if this object is accessible.
      *
      * @return {@code true} if this object is still valid and can be accessed,

--- a/src/main/java/io/netty/buffer/api/RcSupport.java
+++ b/src/main/java/io/netty/buffer/api/RcSupport.java
@@ -106,7 +106,13 @@ public abstract class RcSupport<I extends Rc<I>, T extends RcSupport<I, T>> impl
         return acquires == 0;
     }
 
-    @Override
+    /**
+     * Count the number of borrows of this object.
+     * Note that even if the number of borrows is {@code 0}, this object might not be {@linkplain #isOwned() owned}
+     * because there could be other restrictions involved in ownership.
+     *
+     * @return The number of borrows, if any, of this object.
+     */
     public int countBorrows() {
         return Math.max(acquires, 0);
     }

--- a/src/test/java/io/netty/buffer/api/BufferReadOnlyTest.java
+++ b/src/test/java/io/netty/buffer/api/BufferReadOnlyTest.java
@@ -163,7 +163,6 @@ public class BufferReadOnlyTest extends BufferTestSupport {
             assertTrue(buf.isOwned());
             assertTrue(buf.isAccessible());
             assertThat(buf.countComponents()).isOne();
-            assertThat(buf.countBorrows()).isZero();
             assertEquals((byte) 1, buf.readByte());
             assertEquals((byte) 2, buf.readByte());
             assertEquals((byte) 3, buf.readByte());

--- a/src/test/java/io/netty/buffer/api/BufferTestSupport.java
+++ b/src/test/java/io/netty/buffer/api/BufferTestSupport.java
@@ -970,6 +970,10 @@ public abstract class BufferTestSupport {
         return bs;
     }
 
+    public static int countBorrows(Buffer buf) {
+        return ((RcSupport<?, ?>) buf).countBorrows();
+    }
+
     public static void assertEquals(Buffer expected, Buffer actual) {
         assertThat(toByteArray(actual)).containsExactly(toByteArray(expected));
     }


### PR DESCRIPTION
The state that people really care about is whether or not an Rc has ownership.
Exposing the reference count will probably just confuse people.
The reference count is still exposed on RcSupport because it may be (and is, in the case of ByteBufAdaptor) needed to support implementation details.