### PR TITLE
Fix composite buffer send bug

### DIFF
--- a/src/main/java/io/netty/buffer/api/CompositeBuffer.java
+++ b/src/main/java/io/netty/buffer/api/CompositeBuffer.java
@@ -1351,7 +1351,7 @@ public final class CompositeBuffer extends RcSupport<Buffer, CompositeBuffer> im
                 for (int i = 0; i < sends.length; i++) {
                     received[i] = sends[i].receive();
                 }
-                var composite = new CompositeBuffer(allocator, received, drop, true);
+                var composite = new CompositeBuffer(allocator, received, drop, false);
                 composite.readOnly = readOnly;
                 drop.attach(composite);
                 return composite;

--- a/src/test/java/io/netty/buffer/api/BufferReferenceCountingTest.java
+++ b/src/test/java/io/netty/buffer/api/BufferReferenceCountingTest.java
@@ -350,7 +350,6 @@ public class BufferReferenceCountingTest extends BufferTestSupport {
         }
     }
 
-    @Disabled // TODO
     @ParameterizedTest
     @MethodSource("allocators")
     public void sliceMustBecomeOwnedOnSourceBufferClose(Fixture fixture) {


### PR DESCRIPTION
Fix a bug in CompositeBuffer.send, where the received buffer would not have ownership.
The fix is to avoid incrementing the reference count in the composite buffer constructor call used in the transferOwnership function.