### PR TITLE
feat: Re-use a NOOP tracer

### DIFF
--- a/buffer-api/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
+++ b/buffer-api/src/main/java/io/netty/buffer/api/internal/LifecycleTracer.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 public abstract class LifecycleTracer {
     public static LifecycleTracer get() {
         if (Trace.TRACE_LIFECYCLE_DEPTH == 0) {
-            return new NoOpTracer();
+            return NoOpTracer.INSTANCE;
         }
         StackTracer stackTracer = new StackTracer();
         stackTracer.addTrace(StackTracer.WALKER.walk(new Trace("allocate", 0)));
@@ -45,6 +45,8 @@ public abstract class LifecycleTracer {
     public abstract <E extends Throwable> E attachTrace(E throwable);
 
     private static final class NoOpTracer extends LifecycleTracer {
+        private static final NoOpTracer INSTANCE = new NoOpTracer();
+
         @Override
         public void acquire(int acquires) {
         }


### PR DESCRIPTION
This class (and the parent) has no state - there is no reason we cannot reuse an instance of `NoOpTracer` instead of creating a new one each time.